### PR TITLE
update perl to 5.30 in the build container

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,10 @@ jobs:
             # ISSUE: https://github.com/sfackler/rust-openssl/issues/2036#issuecomment-1724324145
             # If we're running on rhel centos, install needed packages.
             if command -v yum &> /dev/null; then
-                yum update -y && yum install -y perl-core openssl openssl-devel pkgconfig libatomic
+                yum update -y && yum install -y perl-IPC-Cmd rh-perl530 perl-core openssl openssl-devel pkgconfig libatomic
+
+                ldconfig /opt/rh/rh-perl530/root/lib64/
+                export PATH="/opt/rh/rh-perl530/root/bin:$PATH"
 
                 # If we're running on i686 we need to symlink libatomic
                 # in order to build openssl with -latomic flag.


### PR DESCRIPTION
There's currently an [OpenSSL build failure][0] caused by the manylinux container having too old a version of Perl.

The workaround is to update to a newer version of Perl.

[0]: https://github.com/openssl/openssl/issues/25366