### PR TITLE
Fix order of arguments in Reader init

### DIFF
--- a/c2pa/c2pa_api/c2pa_api.py
+++ b/c2pa/c2pa_api/c2pa_api.py
@@ -39,7 +39,7 @@ class Reader(api.Reader):
     def __init__(self, format, stream, manifest_data=None):
         super().__init__()
         if manifest_data is not None:
-            self.from_manifest_data_and_stream(manifest_data, format, stream)
+            self.from_manifest_data_and_stream(manifest_data, format, C2paStream(stream))
         else:
             self.from_stream(format, C2paStream(stream))
 

--- a/c2pa/c2pa_api/c2pa_api.py
+++ b/c2pa/c2pa_api/c2pa_api.py
@@ -39,7 +39,7 @@ class Reader(api.Reader):
     def __init__(self, format, stream, manifest_data=None):
         super().__init__()
         if manifest_data is not None:
-            self.from_manifest_data_and_stream(format, manifest_data, stream)
+            self.from_manifest_data_and_stream(manifest_data, format, stream)
         else:
             self.from_stream(format, C2paStream(stream))
 


### PR DESCRIPTION
The arguments are swapped here based on what is generated for the bindings

Also wrapping the `stream` argument in a C2paStream like the other branch in the init fn