### PR TITLE
Check `validation_status` in unit tests

### DIFF
--- a/c2pa/c2pa_api/c2pa_api.py
+++ b/c2pa/c2pa_api/c2pa_api.py
@@ -38,7 +38,7 @@ class Reader(api.Reader):
     def __init__(self, format, stream, manifest_data=None):
         super().__init__()
         if manifest_data is not None:
-            self.from_manifest_data_and_stream(manifest_data, format, stream)
+            self.from_manifest_data_and_stream(manifest_data, format, C2paStream(stream))
         else:
             self.from_stream(format, C2paStream(stream))
 

--- a/tests/test_unit_tests.py
+++ b/tests/test_unit_tests.py
@@ -98,19 +98,23 @@ class TestBuilder(unittest.TestCase):
             builder.sign(TestBuilder.signer, "image/jpeg", file, output)
             output.seek(0)
             reader = Reader("image/jpeg", output)
-            self.assertIn("Python Test", reader.json())
+            json_data = reader.json()
+            self.assertIn("Python Test", json_data)
+            self.assertNotIn("validation_status", json_data)
 
     def test_archive_sign(self):
         with open(testPath, "rb") as file:
             builder = Builder(TestBuilder.manifestDefinition)
-            archive = byte_array = io.BytesIO(bytearray())
+            archive = io.BytesIO(bytearray())
             builder.to_archive(archive)
             builder = Builder.from_archive(archive)
-            output = byte_array = io.BytesIO(bytearray())
+            output = io.BytesIO(bytearray())
             builder.sign(TestBuilder.signer, "image/jpeg", file, output)
             output.seek(0)
             reader = Reader("image/jpeg", output)
-            self.assertIn("Python Test", reader.json())
+            json_data = reader.json()
+            self.assertIn("Python Test", json_data)
+            self.assertNotIn("validation_status", json_data)
 
     def test_remote_sign(self):
         with open(testPath, "rb") as file:
@@ -120,7 +124,9 @@ class TestBuilder(unittest.TestCase):
             manifest_data = builder.sign(TestBuilder.signer, "image/jpeg", file, output)
             output.seek(0)
             reader = Reader("image/jpeg", output, manifest_data)
-            self.assertIn("Python Test", reader.json())
+            json_data = reader.json()
+            self.assertIn("Python Test", json_data)
+            self.assertNotIn("validation_status", json_data)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The presence of the `validation_status` field suggests an issue with validation, this pr adds a check that it is _not_ present.

This pr also wraps the `stream` argument in a C2paStream to make the tests pass