### PR TITLE
fix: Export CallbackSigner

### DIFF
--- a/c2pa/__init__.py
+++ b/c2pa/__init__.py
@@ -12,6 +12,6 @@
 # each license.
 
 from .c2pa_api import Reader, Builder, create_signer, create_remote_signer, sign_ps256
-from .c2pa import Error, SigningAlg, sdk_version, version
+from .c2pa import Error, SigningAlg, CallbackSigner, sdk_version, version
 
-__all__ = ['Reader', 'Builder', 'create_signer', 'sign_ps256', 'Error', 'SigningAlg', 'sdk_version', 'version', 'create_remote_signer']
+__all__ = ['Reader', 'Builder', 'CallbackSigner', 'create_signer', 'sign_ps256', 'Error', 'SigningAlg', 'sdk_version', 'version', 'create_remote_signer']

--- a/c2pa/c2pa_api/c2pa_api.py
+++ b/c2pa/c2pa_api/c2pa_api.py
@@ -114,6 +114,10 @@ class Builder(api.Builder):
 
     def add_ingredient_file(self, ingredient, path):
         format = os.path.splitext(path)[1][1:]
+        if "title" not in ingredient:
+            if isinstance(ingredient, str):
+                ingredient = json.loads(ingredient)
+            ingredient["title"] = os.path.basename(path)
         with open(path, "rb") as file:
             return self.add_ingredient(ingredient, format, file)
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -51,6 +51,14 @@ manifest_def = {
     ]
 }
 
+ingredient_def = {
+    "relationship": "parentOf",
+    "thumbnail": {
+        "identifier": "A.jpg",
+        "format": "image/jpeg"
+    }
+}
+
 def test_v2_read_cloud_manifest():
     reader = Reader.from_file("tests/fixtures/cloud.jpg")
     manifest = reader.get_active_manifest()
@@ -108,6 +116,8 @@ def test_v2_sign():
         signer = create_signer(sign, SigningAlg.PS256, certs, "http://timestamp.digicert.com")
 
         builder = Builder(manifest_def)
+        
+        builder.add_ingredient_file(ingredient_def, data_dir + "A.jpg")
 
         builder.add_resource_file("A.jpg", data_dir + "A.jpg")
 
@@ -132,6 +142,8 @@ def test_v2_sign():
         assert manifest,["format"] == "image/jpeg"
         # There should be no validation status errors
         assert manifest.get("validation_status") == None
+        assert manifest["ingredients"][0]["relationship"] == "parentOf"
+        assert manifest["ingredients"][0]["title"] == "A.jpg"
     except Exception as e:
         print("Failed to sign manifest store: " + str(e))
         exit(1)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -57,7 +57,7 @@ def test_v2_read_cloud_manifest():
     assert manifest is not None
 
 def test_version():
-    assert version() == "0.5.3"
+    assert version() == "0.6.0"
 
 def test_sdk_version():
     assert "c2pa-rs/" in sdk_version()

--- a/tests/test_unit_tests.py
+++ b/tests/test_unit_tests.py
@@ -25,7 +25,7 @@ testPath = os.path.join(PROJECT_PATH, "tests", "fixtures", "C.jpg")
 
 class TestC2paSdk(unittest.TestCase):
     def test_version(self):
-        self.assertIn("0.5.3", sdk_version())
+        self.assertIn("0.6.0", sdk_version())
 
 
 class TestReader(unittest.TestCase):


### PR DESCRIPTION
fix version based unit tests
Add a title from the filename if no title exists in Builder add_ingredient_file()