### PR TITLE
[NO-MERGE] Uniffi build error example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,8 @@ crate-type = ["lib", "cdylib"]
 normal = ["openssl-src"]
 
 [dependencies]
-c2pa = {version = "0.40.0", features = ["unstable_api", "file_io", "openssl", "pdf", "fetch_remote_manifests"]}
+c2pa = {version = "0.41.0", features = ["unstable_api", "file_io", "openssl", "pdf", "fetch_remote_manifests"]}
+c2pa-crypto = {version = "0.3.0" }
 thiserror = "1.0.49"
 uniffi = "0.28.2"
 openssl-src = "=300.3.1" # Required for openssl-sys

--- a/src/callback_signer.rs
+++ b/src/callback_signer.rs
@@ -11,6 +11,7 @@
 // each license.
 
 use c2pa::{Signer, SigningAlg};
+use c2pa_crypto::raw_signature::RawSigner;
 use log::debug;
 
 use crate::Result;
@@ -56,6 +57,10 @@ impl Signer for RemoteSigner {
     // signer will return a COSE structure
     fn direct_cose_handling(&self) -> bool {
         true
+    }
+
+    fn raw_signer(&self) -> Box<&dyn RawSigner> {
+        todo!()
     }
 }
 


### PR DESCRIPTION
- `impl Signer for RemoteSigner` has a function, `alg`, that returns a `SigningAlg` enum.
- In the used version, `SigningAlg` is a non exhaustive enum: https://github.com/contentauth/c2pa-rs/blob/main/internal/crypto/src/raw_signature/signing_alg.rs#L31

It seems this troubles uniffi, as the build fails:
```
   Compiling c2pa-python v0.6.2 (/git/@CAI/c2pa-python)
error[E0004]: non-exhaustive patterns: `_` not covered
   --> /git/@CAI/c2pa-python/target/debug/build/c2pa-python-3be618cc7bdb8e16/out/c2pa.uniffi.rs:115:1
    |
115 | #[::uniffi::udl_derive(Enum)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ pattern `_` not covered
    |
note: `SigningAlg` defined here
   --> /.cargo/registry/src/index.crates.io-6f17d22bba15001f/c2pa-crypto-0.3.0/src/raw_signature/signing_alg.rs:32:1
    |
32  | pub enum SigningAlg {
    | ^^^^^^^^^^^^^^^^^^^
    = note: the matched value is of type `SigningAlg`
    = note: `SigningAlg` is marked as non-exhaustive, so a wildcard `_` is necessary to match exhaustively
    = note: this error originates in the attribute macro `::uniffi::udl_derive` (in Nightly builds, run with -Z macro-backtrace for more info)
help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
115 | #[::uniffi::udl_derive(Enum)], _ => todo!()
    |                              ++++++++++++++

For more information about this error, try `rustc --explain E0004`.
```