### PR TITLE
chore: update c2pa-rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,7 @@ crate-type = ["lib", "cdylib"]
 normal = ["openssl-src"]
 
 [dependencies]
-c2pa = { version = "0.41.1", features = ["unstable_api", "file_io", "openssl", "pdf", "fetch_remote_manifests"]}
-c2pa-crypto = {version = "0.3.1" }
+c2pa = { version = "0.42.0", features = ["unstable_api", "file_io", "openssl", "pdf", "fetch_remote_manifests"]}
 thiserror = "1.0.49"
 uniffi = "0.28.2"
 openssl-src = "=300.3.1" # Required for openssl-sys

--- a/src/callback_signer.rs
+++ b/src/callback_signer.rs
@@ -11,8 +11,6 @@
 // each license.
 
 use c2pa::{Signer, SigningAlg};
-// RawSigner is currently used only fully qualified
-use c2pa_crypto::{raw_signature::RawSignerError, time_stamp::TimeStampProvider};
 use log::debug;
 
 use crate::Result;
@@ -34,41 +32,6 @@ pub struct RemoteSigner {
     signer_callback: Box<dyn SignerCallback>,
     alg: SigningAlg,
     reserve_size: u32,
-}
-
-impl TimeStampProvider for RemoteSigner {}
-
-impl c2pa_crypto::raw_signature::RawSigner for RemoteSigner {
-    fn sign(&self, data: &[u8]) -> std::result::Result<Vec<u8>, RawSignerError> {
-        let signature_result = self.signer_callback.sign(data.to_vec());
-
-        match signature_result {
-            Ok(signature) => Ok(signature),
-            Err(e) => Err(c2pa_crypto::raw_signature::RawSignerError::IoError(
-                e.to_string(),
-            )),
-        }
-    }
-
-    fn alg(&self) -> c2pa_crypto::raw_signature::SigningAlg {
-        match self.alg {
-            SigningAlg::Es384 => c2pa_crypto::raw_signature::SigningAlg::Es384,
-            SigningAlg::Es512 => c2pa_crypto::raw_signature::SigningAlg::Es512,
-            SigningAlg::Ps256 => c2pa_crypto::raw_signature::SigningAlg::Ps256,
-            SigningAlg::Ps384 => c2pa_crypto::raw_signature::SigningAlg::Ps384,
-            SigningAlg::Ps512 => c2pa_crypto::raw_signature::SigningAlg::Ps512,
-            SigningAlg::Ed25519 => c2pa_crypto::raw_signature::SigningAlg::Ed25519,
-            SigningAlg::Es256 => c2pa_crypto::raw_signature::SigningAlg::Es256,
-        }
-    }
-
-    fn cert_chain(&self) -> std::result::Result<Vec<Vec<u8>>, RawSignerError> {
-        Ok(Vec::new())
-    }
-
-    fn reserve_size(&self) -> usize {
-        self.reserve_size as usize
-    }
 }
 
 impl Signer for RemoteSigner {
@@ -93,10 +56,6 @@ impl Signer for RemoteSigner {
     // signer will return a COSE structure
     fn direct_cose_handling(&self) -> bool {
         true
-    }
-
-    fn raw_signer(&self) -> Box<&dyn c2pa_crypto::raw_signature::RawSigner> {
-        Box::new(self)
     }
 }
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -52,6 +52,7 @@ manifest_def = {
     ]
 }
 
+# ingredient we will use for testing
 ingredient_def = {
     "relationship": "parentOf",
     "thumbnail": {


### PR DESCRIPTION
Follow-up of https://github.com/contentauth/c2pa-python/pull/83/, with new c2pa-rs version.
This version of c2pa-rs allows us to drop the c2pa-crypto dependency.