### PR TITLE
feat: Update c2pa_rs with early v2 claims testing support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["lib", "cdylib"]
 normal = ["openssl-src"]
 
 [dependencies]
-c2pa = {  git="https://github.com/contentauth/c2pa-rs", branch="main", features = ["file_io", "openssl", "pdf", "fetch_remote_manifests"]}
+c2pa = { version = "0.44.0", features = ["file_io", "openssl", "pdf", "fetch_remote_manifests"]}
 thiserror = "1.0.49"
 uniffi = "0.28.2"
 openssl-src = "=300.3.1" # Required for openssl-sys

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "c2pa-python"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 authors = ["Gavin Peacock <gpeacock@adobe.com"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["lib", "cdylib"]
 normal = ["openssl-src"]
 
 [dependencies]
-c2pa = { version = "0.43.0", features = ["unstable_api", "file_io", "openssl", "pdf", "fetch_remote_manifests"]}
+c2pa = {  git="https://github.com/contentauth/c2pa-rs", branch="main", features = ["file_io", "openssl", "pdf", "fetch_remote_manifests"]}
 thiserror = "1.0.49"
 uniffi = "0.28.2"
 openssl-src = "=300.3.1" # Required for openssl-sys

--- a/src/error.rs
+++ b/src/error.rs
@@ -64,7 +64,7 @@ impl Error {
             | TooManyManifestStores => Self::Manifest { reason: err_str },
             ClaimMissing { label } => Self::ManifestNotFound { reason: err_str },
             AssertionDecoding(_) | ClaimDecoding => Self::Decoding { reason: err_str },
-            AssertionEncoding | XmlWriteError | ClaimEncoding => Self::Encoding { reason: err_str },
+            AssertionEncoding(_) | XmlWriteError | ClaimEncoding => Self::Encoding { reason: err_str },
             InvalidCoseSignature { coset_error } => Self::Signature { reason: err_str },
             CoseSignatureAlgorithmNotSupported
             | CoseMissingKey


### PR DESCRIPTION
v2 claims may be created by adding a claim_version = 2 value to a manifest defintion. This is only for early testing since we are still completing work on this feature.