### PR TITLE
chore: Up c2pa Rust dependency version to latest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["lib", "cdylib"]
 normal = ["openssl-src"]
 
 [dependencies]
-c2pa = { version = "0.45.0", features = ["file_io", "openssl", "pdf", "fetch_remote_manifests"]}
+c2pa = { version = "0.45.1", features = ["file_io", "openssl", "pdf", "fetch_remote_manifests"]}
 thiserror = "1.0.49"
 uniffi = "0.28.2"
 openssl-src = "=300.3.1" # Required for openssl-sys


### PR DESCRIPTION
Up c2pa Rust dependency version to latest