### PR TITLE
ci: Update setup for publishing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build
+name: build
 
 on:
   pull_request:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -381,4 +381,6 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages_dir: dist
+          username: __token__
+          password: ${{ secrets.PYPI_TOKEN }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -369,10 +369,16 @@ jobs:
       # IMPORTANT: this permission is mandatory for Trusted Publishing
       id-token: write
     steps:
+      - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
         with:
           pattern: wheels-*
-          name: wheels
-      - name: Publish to PyPI
+          path: dist
+          merge-multiple: true
+      - name: List contents of dist directory
+        run: ls -la dist/
+      - name: Publish to PyPi
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages_dir: dist
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -384,6 +384,10 @@ jobs:
           echo "Event name: ${{ github.event_name }}"
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        env:
+          TWINE_VERBOSE: 1
+          TWINE_DEBUG: 1
+          PYTHONUNBUFFERED: 1
         with:
           packages-dir: dist
           verbose: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -359,14 +359,11 @@ jobs:
 
   release:
     name: Release
-
     if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch' && github.event.inputs.publish == 'true'
-
     runs-on: ubuntu-latest
     environment: pypipublish
     needs: [linux, windows, macos_x86, macos_aarch64, sdist]
     permissions:
-      # IMPORTANT: this permission is mandatory for Trusted Publishing
       id-token: write
     steps:
       - uses: actions/checkout@v4
@@ -377,7 +374,7 @@ jobs:
           merge-multiple: true
       - name: List contents of dist directory
         run: ls -la dist/
-      - name: Publish to PyPi
+      - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: dist

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -374,9 +374,19 @@ jobs:
           merge-multiple: true
       - name: List contents of dist directory
         run: ls -la dist/
+      - name: Debug OIDC token
+        run: |
+          echo "Checking OIDC token information..."
+          echo "GITHUB_TOKEN: ${{ github.token != '' }}"
+          echo "ACTIONS_ID_TOKEN_REQUEST_URL: ${{ env.ACTIONS_ID_TOKEN_REQUEST_URL != '' }}"
+          echo "ACTIONS_ID_TOKEN_REQUEST_TOKEN: ${{ env.ACTIONS_ID_TOKEN_REQUEST_TOKEN != '' }}"
+          echo "ACTIONS_RUNTIME_TOKEN: ${{ env.ACTIONS_RUNTIME_TOKEN != '' }}"
+          echo "ACTIONS_RUNTIME_URL: ${{ env.ACTIONS_RUNTIME_URL != '' }}"
+          echo "__token__ value: __token__"
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: dist
           verbose: true
+          print-hash: true
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -391,6 +391,4 @@ jobs:
         with:
           packages-dir: dist
           verbose: true
-          print-hash: true
-          debug: true
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -392,4 +392,5 @@ jobs:
           packages-dir: dist
           verbose: true
           print-hash: true
+          debug: true
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -374,15 +374,13 @@ jobs:
           merge-multiple: true
       - name: List contents of dist directory
         run: ls -la dist/
-      - name: Debug OIDC token
+      - name: Debug environment
         run: |
-          echo "Checking OIDC token information..."
-          echo "GITHUB_TOKEN: ${{ github.token != '' }}"
-          echo "ACTIONS_ID_TOKEN_REQUEST_URL: ${{ env.ACTIONS_ID_TOKEN_REQUEST_URL != '' }}"
-          echo "ACTIONS_ID_TOKEN_REQUEST_TOKEN: ${{ env.ACTIONS_ID_TOKEN_REQUEST_TOKEN != '' }}"
-          echo "ACTIONS_RUNTIME_TOKEN: ${{ env.ACTIONS_RUNTIME_TOKEN != '' }}"
-          echo "ACTIONS_RUNTIME_URL: ${{ env.ACTIONS_RUNTIME_URL != '' }}"
-          echo "__token__ value: __token__"
+          echo "Environment name: ${{ github.event.inputs.environment }}"
+          echo "Workflow name: ${{ github.workflow }}"
+          echo "Repository: ${{ github.repository }}"
+          echo "Ref: ${{ github.ref }}"
+          echo "Event name: ${{ github.event_name }}"
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build
+name: build
 
 on:
   pull_request:
@@ -363,7 +363,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch' && github.event.inputs.publish == 'true'
 
     runs-on: ubuntu-latest
-    environment: publish
+    environment: pypipublish
     needs: [linux, windows, macos_x86, macos_aarch64, sdist]
     permissions:
       # IMPORTANT: this permission is mandatory for Trusted Publishing

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -363,7 +363,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch' && github.event.inputs.publish == 'true'
 
     runs-on: ubuntu-latest
-    environment: Publish
+    environment: publish
     needs: [linux, windows, macos_x86, macos_aarch64, sdist]
     permissions:
       # IMPORTANT: this permission is mandatory for Trusted Publishing
@@ -381,6 +381,4 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages_dir: dist
-          username: __token__
-          password: ${{ secrets.PYPI_TOKEN }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -381,4 +381,5 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages_dir: dist
+          project: c2pa
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -365,6 +365,7 @@ jobs:
     needs: [linux, windows, macos_x86, macos_aarch64, sdist]
     permissions:
       id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
@@ -376,7 +377,7 @@ jobs:
         run: ls -la dist/
       - name: Debug environment
         run: |
-          echo "Environment name: ${{ github.event.inputs.environment }}"
+          echo "Environment name: ${{ github.event.environment }}"
           echo "Workflow name: ${{ github.workflow }}"
           echo "Repository: ${{ github.repository }}"
           echo "Ref: ${{ github.ref }}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -391,4 +391,6 @@ jobs:
         with:
           packages-dir: dist
           verbose: true
+          print-hash: true
+          skip-existing: true
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -365,15 +365,14 @@ jobs:
     runs-on: ubuntu-latest
     environment: Publish
     needs: [linux, windows, macos_x86, macos_aarch64, sdist]
+    permissions:
+      # IMPORTANT: this permission is mandatory for Trusted Publishing
+      id-token: write
     steps:
       - uses: actions/download-artifact@v4
         with:
           pattern: wheels-*
           name: wheels
       - name: Publish to PyPI
-        uses: PyO3/maturin-action@v1
-        env:
-          MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
-        with:
-          command: upload
-          args: --non-interactive --skip-existing *
+        uses: pypa/gh-action-pypi-publish@release/v1
+

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -382,5 +382,5 @@ jobs:
           # verbose: true
           # print-hash: true
           # Uncomment below for test runs, otherwise fails on existing packages being reuploaded
-          # skip-existing: true
+          skip-existing: true
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -381,5 +381,5 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages_dir: dist
-          project: c2pa
+          verbose: true
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: build
+name: Build
 
 on:
   pull_request:
@@ -375,22 +375,12 @@ jobs:
           merge-multiple: true
       - name: List contents of dist directory
         run: ls -la dist/
-      - name: Debug environment
-        run: |
-          echo "Environment name: ${{ github.event.environment }}"
-          echo "Workflow name: ${{ github.workflow }}"
-          echo "Repository: ${{ github.repository }}"
-          echo "Ref: ${{ github.ref }}"
-          echo "Event name: ${{ github.event_name }}"
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-        env:
-          TWINE_VERBOSE: 1
-          TWINE_DEBUG: 1
-          PYTHONUNBUFFERED: 1
         with:
           packages-dir: dist
-          verbose: true
-          print-hash: true
-          skip-existing: true
+          # verbose: true
+          # print-hash: true
+          # Uncomment below for test runs, otherwise fails on existing packages being reuploaded
+          # skip-existing: true
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: build
+name: Build
 
 on:
   pull_request:
@@ -380,6 +380,6 @@ jobs:
       - name: Publish to PyPi
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          packages_dir: dist
+          packages-dir: dist
           verbose: true
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "c2pa-python"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 authors = ["Gavin Peacock <gpeacock@adobe.com"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "c2pa-python"
-version = "0.8.4"
+version = "0.8.0"
 edition = "2021"
 authors = ["Gavin Peacock <gpeacock@adobe.com"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "c2pa-python"
-version = "0.8.0"
+version = "0.8.4"
 edition = "2021"
 authors = ["Gavin Peacock <gpeacock@adobe.com"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["maturin>=1.7.4,<2.0","uniffi_bindgen>=0.28,<0.30"]
 build-backend = "maturin"
 
 [project]
-name = "c2pa"
+name = "c2pa-python"
 dependencies = ["cffi"]
 requires-python = ">=3.7"
 description = "Python bindings for the C2PA Content Authenticity Initiative (CAI) library"
@@ -28,3 +28,7 @@ urls = {homepage = "https://contentauthenticity.org", repository = "https://gith
 test = [
   "pytest < 5.0.0"
 ]
+
+[tool.maturin]
+python-source = "c2pa"
+module-name = "c2pa"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,5 +30,4 @@ test = [
 ]
 
 [tool.maturin]
-python-source = "c2pa"
 module-name = "c2pa"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -63,7 +63,7 @@ ingredient_def = {
 
 class TestC2paSdk(unittest.TestCase):
     def test_version(self):
-        assert version() == "0.8.0"
+        assert version() == "0.8.4"
 
     def test_sdk_version(self):
         assert "c2pa-rs/" in sdk_version()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -63,7 +63,7 @@ ingredient_def = {
 
 class TestC2paSdk(unittest.TestCase):
     def test_version(self):
-        assert version() == "0.8.4"
+        assert version() == "0.8.0"
 
     def test_sdk_version(self):
         assert "c2pa-rs/" in sdk_version()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -63,7 +63,7 @@ ingredient_def = {
 
 class TestC2paSdk(unittest.TestCase):
     def test_version(self):
-        assert version() == "0.8.0"
+        assert version() == "0.9.0"
 
     def test_sdk_version(self):
         assert "c2pa-rs/" in sdk_version()

--- a/tests/test_unit_tests.py
+++ b/tests/test_unit_tests.py
@@ -25,7 +25,7 @@ testPath = os.path.join(PROJECT_PATH, "tests", "fixtures", "C.jpg")
 
 class TestC2paSdk(unittest.TestCase):
     def test_version(self):
-        self.assertIn("0.8.0", sdk_version())
+        self.assertIn("0.9.0", sdk_version())
 
 
 class TestReader(unittest.TestCase):

--- a/tests/test_unit_tests.py
+++ b/tests/test_unit_tests.py
@@ -25,7 +25,7 @@ testPath = os.path.join(PROJECT_PATH, "tests", "fixtures", "C.jpg")
 
 class TestC2paSdk(unittest.TestCase):
     def test_version(self):
-        self.assertIn("0.8.4", sdk_version())
+        self.assertIn("0.8.0", sdk_version())
 
 
 class TestReader(unittest.TestCase):

--- a/tests/test_unit_tests.py
+++ b/tests/test_unit_tests.py
@@ -25,7 +25,7 @@ testPath = os.path.join(PROJECT_PATH, "tests", "fixtures", "C.jpg")
 
 class TestC2paSdk(unittest.TestCase):
     def test_version(self):
-        self.assertIn("0.8.0", sdk_version())
+        self.assertIn("0.8.4", sdk_version())
 
 
 class TestReader(unittest.TestCase):


### PR DESCRIPTION
Replaces https://github.com/contentauth/c2pa-python/pull/94.

Details about the update are logged in the comments on the PR (see below).

Example runs:
- Demo 1: (debug) https://github.com/contentauth/c2pa-python/actions/runs/14895338961 (skips real upload, since I did not bump the version number yet and it exists in PyPI. But we get passed the point when an upload would have happened).
- Demo 2: (without debug logs) https://github.com/contentauth/c2pa-python/actions/runs/14895530386 (set to skip-existing files, so fails after attempting upload, as expected)
- Demo 3: (without debug logs) https://github.com/contentauth/c2pa-python/actions/runs/14895714503 (skips real upload, since I did not bump the version number yet and it exists in PyPI. Except that, showcases a flow running).