### PR TITLE
fix: Docs update

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -8,7 +8,9 @@ The `examples/training.py` script demonstrates how to add a "Do Not Train" asser
 
 ### Signing and Verifying Assets
 
-The `examples/sign.py` script shows how to sign an asset with a C2PA manifest and verify it.
+The `examples/sign.py` script shows how to sign an asset with a C2PA manifest and verify it using a callback signer. Callback signers let you define signing logic, eg. where to load keys from.
+
+The `examples/sign_info.py` script shows how to sign an asset with a C2PA manifest and verify it using a "default" signer created with the needed signer information.
 
 ## Running the Examples
 
@@ -21,6 +23,11 @@ Then you can run the examples with the following commands:
 python examples/training.py
 
 # Run the signing and verification example
+# In this example, signing is done with a Signer created using SignerInfo
+python examples/sign_info.py
+
+# Run the signing and verification example
+# In this example, signing is done using a callback signer
 python examples/sign.py
 ```
 

--- a/examples/sign.py
+++ b/examples/sign.py
@@ -58,15 +58,17 @@ manifest_definition = {
     "ingredients": [],
     "assertions": [
         {
-            'label': 'stds.schema-org.CreativeWork',
-            'data': {
-                '@context': 'http://schema.org/',
-                '@type': 'CreativeWork',
-                'author': [
-                    {'@type': 'Person', 'name': 'Example User'}
+            "label": "c2pa.actions",
+            "data": {
+                "actions": [
+                    {
+                        "action": "c2pa.created",
+                        "parameters": {
+                            # could hold additional information about this step
+                        }
+                    }
                 ]
-            },
-            'kind': 'Json'
+            }
         }
     ]
 }

--- a/examples/sign_info.py
+++ b/examples/sign_info.py
@@ -19,6 +19,10 @@ import c2pa
 fixtures_dir = os.path.join(os.path.dirname(__file__), "../tests/fixtures/")
 output_dir = os.path.join(os.path.dirname(__file__), "../output/")
 
+# Note: Builder, Reader, and Signer support being used as context managers
+# (with 'with' statements), but this example shows manual usage which requires
+# explicitly calling the close() function to clean up resources.
+
 # Ensure the output directory exists
 if not os.path.exists(output_dir):
     os.makedirs(output_dir)
@@ -32,11 +36,13 @@ print("\nReading existing C2PA metadata:")
 with open(fixtures_dir + "C.jpg", "rb") as file:
     reader = c2pa.Reader("image/jpeg", file)
     print(reader.json())
+    reader.close()
 
 # Create a signer from certificate and key files
 certs = open(fixtures_dir + "es256_certs.pem", "rb").read()
 key = open(fixtures_dir + "es256_private.key", "rb").read()
 
+# Define Signer information
 signer_info = c2pa.C2paSignerInfo(
     alg=b"es256",  # Use bytes instead of encoded string
     sign_cert=certs,
@@ -44,6 +50,7 @@ signer_info = c2pa.C2paSignerInfo(
     ta_url=b"http://timestamp.digicert.com"  # Use bytes and add timestamp URL
 )
 
+# Create the Signer from the information
 signer = c2pa.Signer.from_info(signer_info)
 
 # Create a manifest definition as a dictionary
@@ -74,6 +81,7 @@ manifest_definition = {
     ]
 }
 
+# Create the builder with the manifest definition
 builder = c2pa.Builder(manifest_definition)
 
 # Sign the image
@@ -87,6 +95,11 @@ print("\nReading signed image metadata:")
 with open(output_dir + "C_signed.jpg", "rb") as file:
     reader = c2pa.Reader("image/jpeg", file)
     print(reader.json())
+    reader.close()
+
+# Clean up resources manually, since we are not using with statements
+signer.close()
+builder.close()
 
 print("\nExample completed successfully!")
 

--- a/examples/sign_using_signer_info.py
+++ b/examples/sign_using_signer_info.py
@@ -11,13 +11,10 @@
 # each license.
 
 # This example shows how to sign an image with a C2PA manifest
-# using a callback signer and read the metadata added to the image.
+# and read the metadata added to the image.
 
 import os
 import c2pa
-from cryptography.hazmat.primitives import hashes, serialization
-from cryptography.hazmat.primitives.asymmetric import ec
-from cryptography.hazmat.backends import default_backend
 
 fixtures_dir = os.path.join(os.path.dirname(__file__), "../tests/fixtures/")
 output_dir = os.path.join(os.path.dirname(__file__), "../output/")
@@ -36,43 +33,27 @@ with open(fixtures_dir + "C.jpg", "rb") as file:
     reader = c2pa.Reader("image/jpeg", file)
     print(reader.json())
 
-# Load certificates and private key (here from the test fixtures)
-# This is OK for development, but in production you should use a
-# secure way to load the certificates and private key.
+# Create a signer from certificate and key files
 certs = open(fixtures_dir + "es256_certs.pem", "rb").read()
 key = open(fixtures_dir + "es256_private.key", "rb").read()
 
-# Define a callback signer function
-def callback_signer_es256(data: bytes) -> bytes:
-    """Callback function that signs data using ES256 algorithm."""
-    private_key = serialization.load_pem_private_key(
-        key,
-        password=None,
-        backend=default_backend()
-    )
-    signature = private_key.sign(
-        data,
-        ec.ECDSA(hashes.SHA256())
-    )
-    return signature
-
-# Create a signer using the callback function we defined
-signer = c2pa.Signer.from_callback(
-    callback=callback_signer_es256,
-    alg=c2pa.C2paSigningAlg.ES256,
-    certs=certs.decode('utf-8'),
-    tsa_url="http://timestamp.digicert.com"
+signer_info = c2pa.C2paSignerInfo(
+    alg=b"es256",  # Use bytes instead of encoded string
+    sign_cert=certs,
+    private_key=key,
+    ta_url=b"http://timestamp.digicert.com"  # Use bytes and add timestamp URL
 )
 
+signer = c2pa.Signer.from_info(signer_info)
+
 # Create a manifest definition as a dictionary
-# This manifest follows the V2 manifest format
+# This examples signs using a V1 manifest
 manifest_definition = {
     "claim_generator": "python_example",
     "claim_generator_info": [{
         "name": "python_example",
         "version": "0.0.1",
     }],
-    "claim_version": 2,
     "format": "image/jpeg",
     "title": "Python Example Image",
     "ingredients": [],
@@ -93,20 +74,13 @@ manifest_definition = {
     ]
 }
 
-# Create the builder with the manifest definition
 builder = c2pa.Builder(manifest_definition)
 
-# Sign the image with the signer created above,
-# which will use the callback signer
-print("\nSigning the image file...")
-builder.sign_file(
-    source_path=fixtures_dir + "C.jpg",
-    dest_path=output_dir + "C_signed.jpg",
-    signer=signer
-)
-
-# Clean up the signer
-signer.close()
+# Sign the image
+print("\nSigning the image...")
+with open(fixtures_dir + "C.jpg", "rb") as source:
+    with open(output_dir + "C_signed.jpg", "wb") as dest:
+        result = builder.sign(signer, "image/jpeg", source, dest)
 
 # Read the signed image to verify
 print("\nReading signed image metadata:")

--- a/examples/training.py
+++ b/examples/training.py
@@ -42,25 +42,7 @@ import operator
 def getitem(d, key):
     return reduce(operator.getitem, key, d)
 
-
-# This function signs data with PS256 using a private key
-def sign_ps256(data: bytes, key: bytes) -> bytes:
-    private_key = serialization.load_pem_private_key(
-        key,
-        password=None,
-    )
-    signature = private_key.sign(
-        data,
-        padding.PSS(
-            mgf=padding.MGF1(hashes.SHA256()),
-            salt_length=padding.PSS.MAX_LENGTH
-        ),
-        hashes.SHA256()
-    )
-    return signature
-
 # First create an asset with a do not train assertion
-
 # Define a manifest with the do not train assertion
 manifest_json = {
     "claim_generator_info": [{
@@ -72,19 +54,19 @@ manifest_json = {
         "format": "image/jpeg",
         "identifier": "thumbnail"
     },
-    "assertions": [
-    {
-      "label": "c2pa.training-mining",
-      "data": {
-        "entries": {
-          "c2pa.ai_generative_training": { "use": "notAllowed" },
-          "c2pa.ai_inference": { "use": "notAllowed" },
-          "c2pa.ai_training": { "use": "notAllowed" },
-          "c2pa.data_mining": { "use": "notAllowed" }
+    "assertions": [{
+        "label": "cawg.training-mining",
+        "data": {
+            "entries": {
+                "cawg.ai_inference": {
+                    "use": "notAllowed"
+                },
+                "cawg.ai_generative_training": {
+                    "use": "notAllowed"
+                }
+            }
         }
-      }
-    }
-  ]
+    }]
 }
 
 ingredient_json = {
@@ -145,9 +127,11 @@ try:
     manifest_store = json.loads(reader.json())
 
     manifest = manifest_store["manifests"][manifest_store["active_manifest"]]
+
     for assertion in manifest["assertions"]:
-        if assertion["label"] == "c2pa.training-mining":
-            if getitem(assertion, ("data","entries","c2pa.ai_training","use")) == "notAllowed":
+        print(assertion)
+        if assertion["label"] == "cawg.training-mining":
+            if getitem(assertion, ("data","entries","cawg.ai_generative_training","use")) == "notAllowed":
                 allowed = False
 
     # get the ingredient thumbnail and save it to a file using resource_to_stream


### PR DESCRIPTION
- Add an example that showcases v2 manifest signing + callback signer
- Keep old example (renamed to signer_info) showing signing using signer information and v1 manifest
- Add unit tests for V2 signing