### PR TITLE
chore: Bump version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "c2pa-python"
-version = "0.12.0"
+version = "0.12.1"
 requires-python = ">=3.10"
 description = "Python bindings for the C2PA Content Authenticity Initiative (CAI) library"
 readme = { file = "README.md", content-type = "text/markdown" }


### PR DESCRIPTION
Bump version number so publish doesn't get ignored. Bugfix since I don't know about new features that would mean we want a minor bump.

PyPi test publish is uncommented, so this should lead to a version release: https://github.com/contentauth/c2pa-python/blob/main/.github/workflows/build.yml#L459-L460