### PR TITLE
fix: Builder and Reader initialized checks

### DIFF
--- a/src/c2pa/c2pa.py
+++ b/src/c2pa/c2pa.py
@@ -1514,7 +1514,6 @@ class Reader:
                         )
                     )
 
-                # Mark as initialized after successful creation
                 self._initialized = True
 
     def __enter__(self):
@@ -2118,7 +2117,6 @@ class Builder:
                 )
             )
 
-        # Mark as initialized only after successful creation
         self._initialized = True
 
     @classmethod


### PR DESCRIPTION
- Improve internal state checks
- Make sure no Reader or Builder is partially initialized (in case of failures during construction)