### PR TITLE
feat: Add convenience APIs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,6 +36,29 @@ jobs:
         id: read-version
         run: echo "version=$(cat c2pa-native-version.txt | tr -d '\r\n')" >> $GITHUB_OUTPUT
 
+  check-format:
+    name: Check code format and syntax
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Install development dependencies
+        run: python -m pip install -r requirements-dev.txt
+
+      - name: Check Python syntax
+        run: python3 -m py_compile src/c2pa/c2pa.py
+        continue-on-error: true
+
+      - name: Check code style with flake8
+        run: flake8 src/c2pa/c2pa.py
+        continue-on-error: true
+
   tests-unix:
     name: Unit tests for developer setup (Unix)
     needs: read-version

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
         run: echo "version=$(cat c2pa-native-version.txt | tr -d '\r\n')" >> $GITHUB_OUTPUT
 
   check-format:
-    name: Check code format and syntax
+    name: Check code format
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "c2pa-python"
-version = "0.25.0"
+version = "0.26.0"
 requires-python = ">=3.10"
 description = "Python bindings for the C2PA Content Authenticity Initiative (CAI) library"
 readme = { file = "README.md", content-type = "text/markdown" }

--- a/src/c2pa/c2pa.py
+++ b/src/c2pa/c2pa.py
@@ -1661,16 +1661,6 @@ class Reader:
             C2paError: If there was an error getting the manifest JSON
             KeyError: If the active_manifest key is missing from the JSON
             ValueError: If the active manifest ID is not found in the manifests
-
-        Example:
-            ```python
-            with Reader("image/jpeg", file) as reader:
-                active_manifest = reader.get_active_manifest()
-                print(f"Title: {active_manifest['title']}")
-                print(f"Format: {active_manifest['format']}")
-                for assertion in active_manifest['assertions']:
-                    print(f"Assertion: {assertion['label']}")
-            ```
         """
         # Get the full manifest JSON
         manifest_json_str = self.json()

--- a/src/c2pa/c2pa.py
+++ b/src/c2pa/c2pa.py
@@ -1623,6 +1623,9 @@ class Reader:
                     self._manifest_json_str_cache
                 )
             except json.JSONDecodeError:
+                # Reset cache to reattempt read, possibly
+                self._manifest_data_cache = None
+                self._manifest_json_str_cache = None
                 # Failed to parse manifest JSON
                 return None
 

--- a/src/c2pa/c2pa.py
+++ b/src/c2pa/c2pa.py
@@ -1660,7 +1660,6 @@ class Reader:
         Raises:
             C2paError: If there was an error getting the manifest JSON
             KeyError: If the active_manifest key is missing from the JSON
-            ValueError: If the active manifest ID is not found in the manifests
         """
         # Self-read to get the JSON
         manifest_json_str = self.json()
@@ -1681,9 +1680,41 @@ class Reader:
 
         manifests = manifest_data["manifests"]
         if active_manifest_id not in manifests:
-            raise ValueError("Active manifest idnot found in manifests")
+            raise KeyError("Active manifest id not found in manifest store")
 
         return manifests[active_manifest_id]
+
+    def get_manifest_by_label(self, label: str) -> dict:
+        """Get a specific manifest from the manifest store by its label.
+
+        This method retrieves the manifest JSON and extracts the manifest
+        that corresponds to the provided manifest label/ID.
+
+        Args:
+            label: The manifest label/ID to look up in the manifest store
+
+        Returns:
+            A dictionary containing the manifest data for the specified label.
+
+        Raises:
+            C2paError: If there was an error getting the manifest JSON
+            KeyError: If the manifests key is missing from the JSON
+        """
+        # Self-read to get the JSON
+        manifest_json_str = self.json()
+        try:
+            manifest_data = json.loads(manifest_json_str)
+        except json.JSONDecodeError as e:
+            raise C2paError(f"Failed to parse manifest JSON: {str(e)}") from e
+
+        if "manifests" not in manifest_data:
+            raise KeyError("No 'manifests' key found in manifest data")
+
+        manifests = manifest_data["manifests"]
+        if label not in manifests:
+            raise KeyError("Manifest not found in manifest store")
+
+        return manifests[label]
 
     def get_validation_state(self) -> Optional[str]:
         """Get the validation state of the manifest store.

--- a/src/c2pa/c2pa.py
+++ b/src/c2pa/c2pa.py
@@ -1246,9 +1246,6 @@ class Reader:
         ```
         with Reader("image/jpeg", output) as reader:
             manifest_json = reader.json()
-            active_manifest = reader.get_active_manifest()
-            validation_state = reader.get_validation_state()
-            validation_results = reader.validation_results()
         ```
         Where `output` is either an in-memory stream or an opened file.
     """

--- a/src/c2pa/c2pa.py
+++ b/src/c2pa/c2pa.py
@@ -1662,28 +1662,24 @@ class Reader:
             KeyError: If the active_manifest key is missing from the JSON
             ValueError: If the active manifest ID is not found in the manifests
         """
-        # Get the full manifest JSON
+        # Self-read to get the JSON
         manifest_json_str = self.json()
-
         try:
-            # Parse the JSON
             manifest_data = json.loads(manifest_json_str)
         except json.JSONDecodeError as e:
             raise C2paError(f"Failed to parse manifest JSON: {str(e)}") from e
 
-        # Extract the active manifest ID
+        # Get the active manfiest id/label
         if "active_manifest" not in manifest_data:
             raise KeyError("No 'active_manifest' key found in manifest data")
 
         active_manifest_id = manifest_data["active_manifest"]
 
-        # Get the manifests object to retrieve the active manifest from there
+        # Retrieve the active manifest data using manifest id/label
         if "manifests" not in manifest_data:
             raise KeyError("No 'manifests' key found in manifest data")
 
         manifests = manifest_data["manifests"]
-
-        # Look up the active manifest
         if active_manifest_id not in manifests:
             raise ValueError("Active manifest idnot found in manifests")
 
@@ -1705,12 +1701,11 @@ class Reader:
         """
         manifest_json_str = self.json()
         try:
-            # Parse the JSON
+            # Self-read to get the JSON
             manifest_data = json.loads(manifest_json_str)
         except json.JSONDecodeError as e:
             raise C2paError(f"Failed to parse manifest JSON: {str(e)}") from e
 
-        # Extract the validation_state field
         return manifest_data.get("validation_state")
 
     def get_validation_results(self) -> Optional[dict]:
@@ -1730,12 +1725,11 @@ class Reader:
         """
         manifest_json_str = self.json()
         try:
-            # Parse the JSON
+            # Self-read to get the JSON
             manifest_data = json.loads(manifest_json_str)
         except json.JSONDecodeError as e:
             raise C2paError(f"Failed to parse manifest JSON: {str(e)}") from e
 
-        # Extract the validation_results field
         return manifest_data.get("validation_results")
 
     def resource_to_stream(self, uri: str, stream: Any) -> int:

--- a/src/c2pa/c2pa.py
+++ b/src/c2pa/c2pa.py
@@ -1723,7 +1723,7 @@ class Reader:
         except C2paError.ManifestNotFound:
             return None
 
-    def get_manifest_from_label(self, label: str) -> Optional[dict]:
+    def get_manifest(self, label: str) -> Optional[dict]:
         """Get a specific manifest from the manifest store by its label.
 
         This method retrieves the manifest JSON and extracts the manifest

--- a/tests/test_unit_tests.py
+++ b/tests/test_unit_tests.py
@@ -64,6 +64,15 @@ class TestReader(unittest.TestCase):
             json_data = reader.json()
             self.assertIn(DEFAULT_TEST_FILE_NAME, json_data)
 
+    def test_stream_read_get_active_manifest(self):
+        with open(self.testPath, "rb") as file:
+            reader = Reader("image/jpeg", file)
+            active_manifest = reader.get_active_manifest()
+
+            # Check the returned manifest label/key
+            expected_label = "contentauth:urn:uuid:c85a2b90-f1a0-4aa4-b17f-f938b475804e"
+            self.assertEqual(active_manifest["label"], expected_label)
+
     def test_reader_detects_unsupported_mimetype_on_stream(self):
         with open(self.testPath, "rb") as file:
             with self.assertRaises(Error.NotSupported):

--- a/tests/test_unit_tests.py
+++ b/tests/test_unit_tests.py
@@ -80,11 +80,9 @@ class TestReader(unittest.TestCase):
             # Test getting manifest by the specific label
             label = "contentauth:urn:uuid:c85a2b90-f1a0-4aa4-b17f-f938b475804e"
             manifest = reader.get_manifest_by_label(label)
-
-            # Check that we got the correct manifest
             self.assertEqual(manifest["label"], label)
 
-            # Verify it's the same as the active manifest (since there's only one)
+            # It should be the active manifest too, so cross-check
             active_manifest = reader.get_active_manifest()
             self.assertEqual(manifest, active_manifest)
 
@@ -95,8 +93,6 @@ class TestReader(unittest.TestCase):
 
             non_active_label = "urn:uuid:54281c07-ad34-430e-bea5-112a18facf0b"
             non_active_manifest = reader.get_manifest_by_label(non_active_label)
-
-            # Check that we got the correct manifest
             self.assertEqual(non_active_manifest["label"], non_active_label)
 
             # Verify it's not the active manifest

--- a/tests/test_unit_tests.py
+++ b/tests/test_unit_tests.py
@@ -357,7 +357,7 @@ class TestReader(unittest.TestCase):
             self.assertFalse(reader.is_embedded())
 
     def test_sign_and_read_is_not_embedded(self):
-        """Test the is_embedded method returns correct values for embedded and remote manifests."""
+        """Test the is_embedded method returns correct values for remote manifests."""
 
         with open(os.path.join(self.data_dir, "es256_certs.pem"), "rb") as cert_file:
             certs = cert_file.read()

--- a/tests/test_unit_tests.py
+++ b/tests/test_unit_tests.py
@@ -73,6 +73,26 @@ class TestReader(unittest.TestCase):
             expected_label = "contentauth:urn:uuid:c85a2b90-f1a0-4aa4-b17f-f938b475804e"
             self.assertEqual(active_manifest["label"], expected_label)
 
+    def test_stream_read_get_validation_state(self):
+        with open(self.testPath, "rb") as file:
+            reader = Reader("image/jpeg", file)
+            validation_state = reader.get_validation_state()
+            self.assertIsNotNone(validation_state)
+            self.assertEqual(validation_state, "Valid")
+
+    def test_stream_read_get_validation_results(self):
+        with open(self.testPath, "rb") as file:
+            reader = Reader("image/jpeg", file)
+            validation_results = reader.get_validation_results()
+
+            self.assertIsNotNone(validation_results)
+            self.assertIsInstance(validation_results, dict)
+
+            # Verify some active manifest validation results
+            self.assertIn("activeManifest", validation_results)
+            active_manifest_results = validation_results["activeManifest"]
+            self.assertIsInstance(active_manifest_results, dict)
+
     def test_reader_detects_unsupported_mimetype_on_stream(self):
         with open(self.testPath, "rb") as file:
             with self.assertRaises(Error.NotSupported):

--- a/tests/test_unit_tests.py
+++ b/tests/test_unit_tests.py
@@ -96,6 +96,7 @@ class TestReader(unittest.TestCase):
             self.assertEqual(non_active_manifest["label"], non_active_label)
 
             # Verify it's not the active manifest
+            # (that test case has only one other manifest that is not the active manifest)
             active_manifest = reader.get_active_manifest()
             self.assertNotEqual(non_active_manifest, active_manifest)
             self.assertNotEqual(non_active_manifest["label"], active_manifest["label"])
@@ -105,7 +106,7 @@ class TestReader(unittest.TestCase):
         with open(video_path, "rb") as file:
             reader = Reader("video/mp4", file)
 
-            # Try to get a manifest with a label that clearly doesn't exist
+            # Try to get a manifest with a label that clearly doesn't exist...
             non_existing_label = "urn:uuid:clearly-not-existing"
             with self.assertRaises(KeyError):
                 reader.get_manifest_by_label(non_existing_label)
@@ -125,7 +126,6 @@ class TestReader(unittest.TestCase):
             self.assertIsNotNone(validation_results)
             self.assertIsInstance(validation_results, dict)
 
-            # Verify some active manifest validation results
             self.assertIn("activeManifest", validation_results)
             active_manifest_results = validation_results["activeManifest"]
             self.assertIsInstance(active_manifest_results, dict)

--- a/tests/test_unit_tests.py
+++ b/tests/test_unit_tests.py
@@ -73,13 +73,13 @@ class TestReader(unittest.TestCase):
             expected_label = "contentauth:urn:uuid:c85a2b90-f1a0-4aa4-b17f-f938b475804e"
             self.assertEqual(active_manifest["label"], expected_label)
 
-    def test_get_manifest_from_label(self):
+    def test_get_manifest(self):
         with open(self.testPath, "rb") as file:
             reader = Reader("image/jpeg", file)
 
             # Test getting manifest by the specific label
             label = "contentauth:urn:uuid:c85a2b90-f1a0-4aa4-b17f-f938b475804e"
-            manifest = reader.get_manifest_from_label(label)
+            manifest = reader.get_manifest(label)
             self.assertEqual(manifest["label"], label)
 
             # It should be the active manifest too, so cross-check
@@ -92,7 +92,7 @@ class TestReader(unittest.TestCase):
             reader = Reader("video/mp4", file)
 
             non_active_label = "urn:uuid:54281c07-ad34-430e-bea5-112a18facf0b"
-            non_active_manifest = reader.get_manifest_from_label(non_active_label)
+            non_active_manifest = reader.get_manifest(non_active_label)
             self.assertEqual(non_active_manifest["label"], non_active_label)
 
             # Verify it's not the active manifest
@@ -109,7 +109,7 @@ class TestReader(unittest.TestCase):
             # Try to get a manifest with a label that clearly doesn't exist...
             non_existing_label = "urn:uuid:clearly-not-existing"
             with self.assertRaises(KeyError):
-                reader.get_manifest_from_label(non_existing_label)
+                reader.get_manifest(non_existing_label)
 
     def test_stream_read_get_validation_state(self):
         with open(self.testPath, "rb") as file:


### PR DESCRIPTION
Code changes:
Some of our other SDKs have convenience methods that help dealing with manifests.
I thought this is a good idea to have too for developer experience, so I added the following, all on the Reader:
- `get_active_manifest`, returns the active manifest (parsed as a dictionary for easy use);
- `get_manifest_by_label`, retrieves any manifest based on its label/id and returns it as dictionary;
- `get_validation_state`, returns just the validation state of the whole manifest store;
- `get_validation_results` returns all the validation results from the manifest store (and only the validation results).

Workflow changes:
- Add formatting and syntax check in github workflow