### PR TITLE
fix: Improve error clearing

### DIFF
--- a/src/c2pa/c2pa.py
+++ b/src/c2pa/c2pa.py
@@ -250,7 +250,7 @@ def _clear_error_state():
     This function should be called at the beginning of object initialization
     and before any operations that could potentially raise an error,
     to ensure that stale error states from previous operations don't interfere
-    with new objects being created.
+    with new objects being created, or independent function calls.
     """
     error = _lib.c2pa_error()
     if error:


### PR DESCRIPTION
I noticed that in some cases (example, when objects throw on instantiation), the C-level errors may not be properly cleaned up. This is to improve (slightly) on the situation.