### PR TITLE
fix: Close Builder after signing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "c2pa-python"
-version = "0.32.9"
+version = "0.32.10"
 requires-python = ">=3.10"
 description = "Python bindings for the C2PA Content Authenticity Initiative (CAI) library"
 readme = { file = "README.md", content-type = "text/markdown" }

--- a/src/c2pa/c2pa.py
+++ b/src/c2pa/c2pa.py
@@ -3529,15 +3529,9 @@ class Builder(ManagedResource):
                     dest_stream._stream,
                     ctypes.byref(manifest_bytes_ptr),
                 )
-            # c2pa_builder_sign / c2pa_builder_sign_context BORROW the builder
-            # (&mut self on the Rust side); they do NOT take ownership. The
-            # native Builder is still owned by us and must be freed. Marking it
-            # only "consumed" nulls the handle WITHOUT calling c2pa_free, leaking
-            # a fully-populated Builder (manifest store + claim + ingredients) on
-            # every sign. close() frees it and keeps the Builder closed so it is
-            # not reused (a Builder is single-shot). _mark_consumed() stays
-            # correct for the real consume-and-return calls (with_definition /
-            # with_archive), just not sign.
+            # Sign borrows the Builder without taking ownership.
+            # Closing here ensures resources clean up,
+            # and single use/single sign done by a Builder.
             self.close()
         except Exception as e:
             self.close()

--- a/src/c2pa/c2pa.py
+++ b/src/c2pa/c2pa.py
@@ -3529,10 +3529,18 @@ class Builder(ManagedResource):
                     dest_stream._stream,
                     ctypes.byref(manifest_bytes_ptr),
                 )
-            # Builder pointer consumed by Rust FFI at this point
-            self._mark_consumed()
+            # c2pa_builder_sign / c2pa_builder_sign_context BORROW the builder
+            # (&mut self on the Rust side); they do NOT take ownership. The
+            # native Builder is still owned by us and must be freed. Marking it
+            # only "consumed" nulls the handle WITHOUT calling c2pa_free, leaking
+            # a fully-populated Builder (manifest store + claim + ingredients) on
+            # every sign. close() frees it and keeps the Builder closed so it is
+            # not reused (a Builder is single-shot). _mark_consumed() stays
+            # correct for the real consume-and-return calls (with_definition /
+            # with_archive), just not sign.
+            self.close()
         except Exception as e:
-            self._mark_consumed()
+            self.close()
             raise C2paError(f"Error during signing: {e}")
 
         _check_ffi_operation_result(result,

--- a/src/c2pa/c2pa.py
+++ b/src/c2pa/c2pa.py
@@ -3486,6 +3486,8 @@ class Builder(ManagedResource):
         When `signer` is provided, calls `c2pa_builder_sign` (explicit
         signer).  When `signer` is `None`, calls
         `c2pa_builder_sign_context` (context-based signer).
+        Sign can only be called once on a Builder, as Builder objects
+        are single-sign use. The Builder is closed after signing.
 
         Args:
             format: The MIME type or extension of the content
@@ -3567,6 +3569,8 @@ class Builder(ManagedResource):
         dest: Any = None,
     ) -> bytes:
         """Shared signing logic for sign().
+        Sign can only be called once on a Builder, as Builder objects
+        are single-sign use. The Builder is closed after signing.
 
         Args:
             signer: The signer to use, or None for context signer.
@@ -3637,6 +3641,8 @@ class Builder(ManagedResource):
         If no signer is provided, the context's signer is
         used (builder must have been created with a Context
         that has a signer).
+        Sign can only be called once on a Builder, as Builder objects
+        are single-sign use. The Builder is closed after signing.
 
         Args:
             signer: The signer to use. If not provided, the


### PR DESCRIPTION
## Changes in this pull request
- Close Builder to force resources clean up
- A Builder should not be reused for multiple signing anyway

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
