### PR TITLE
fix: Stamp owning threads to avoid finalization issues on recycled addresses 

### DIFF
--- a/src/c2pa/c2pa.py
+++ b/src/c2pa/c2pa.py
@@ -21,11 +21,18 @@ import sys
 import os
 import warnings
 import weakref
+import threading
 from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Optional, Union, Callable, Any, overload
 import io
-from .lib import dynamically_load_library, record_owner_pid, is_foreign_process
+from .lib import (
+    dynamically_load_library,
+    record_owner_pid,
+    is_foreign_process,
+    record_owner_thread,
+    is_foreign_thread,
+)
 import mimetypes
 from itertools import count
 
@@ -265,6 +272,7 @@ class ManagedResource:
         self._lifecycle_state = LifecycleState.UNINITIALIZED
         self._handle = None
         record_owner_pid(self)
+        record_owner_thread(self)
 
     @staticmethod
     def _free_native_ptr(ptr):
@@ -602,7 +610,23 @@ class ManagedResource:
         self.close()
 
     def __del__(self):
-        """Free native resources if close() was not called."""
+        """Free native resources if close() was not called.
+
+        Only the finalizer path is thread-guarded: an explicit close() from a
+        foreign thread is a explicit, supported operation and still frees.
+        A finalizer running on a foreign thread is collector-driven, not
+        explicit, and freeing there can race a recycled address on the
+        thread that actually owns the handle.
+        """
+        if is_foreign_thread(self):
+            logger.debug(
+                "Skipping native free for %s: finalizing thread %s is not "
+                "the owning thread (foreign_thread), handle %s",
+                type(self).__name__, threading.get_ident(),
+                getattr(self, '_handle', None))
+            self._handle = None
+            self._lifecycle_state = LifecycleState.CLOSED
+            return
         self._cleanup_resources()
 
 
@@ -2014,6 +2038,7 @@ class Stream:
 
         self._initialized = True
         record_owner_pid(self)
+        record_owner_thread(self)
 
     def __enter__(self):
         """Context manager entry."""
@@ -2038,6 +2063,16 @@ class Stream:
             if hasattr(self, '_closed') and not self._closed:
                 stream = self._stream
                 if hasattr(self, '_stream') and stream:
+                    if is_foreign_thread(self):
+                        logger.debug(
+                            "Skipping native free for Stream: finalizing "
+                            "thread %s is not the owning thread "
+                            "(foreign_thread), handle %s",
+                            threading.get_ident(), stream)
+                        self._stream = None
+                        self._closed = True
+                        self._initialized = False
+                        return
                     # Use internal cleanup to avoid calling close() which could
                     # cause issues
                     try:

--- a/src/c2pa/lib.py
+++ b/src/c2pa/lib.py
@@ -9,6 +9,7 @@ import sys
 import ctypes
 import logging
 import platform
+import threading
 from pathlib import Path
 from typing import Optional
 from enum import Enum
@@ -324,3 +325,22 @@ def is_foreign_process(obj):
     Defensive default: if _owner_pid was never set, returns False (no regression)."""
     owner = getattr(obj, '_owner_pid', None)
     return owner is not None and owner != os.getpid()
+
+
+def record_owner_thread(obj):
+    """Keep the identifier of the thread that created this native-handle wrapper.
+    """
+    obj._owner_thread = threading.get_ident()
+
+
+def is_foreign_thread(obj):
+    """Return True when this object is being finalized on a different thread
+    than the one that created it. Freeing a native handle from a thread that
+    never made the owning call can race an allocator that has already handed
+    the freed address to a live object on a third thread, destroying it.
+    Callers must skip native frees when this returns True.
+    Default: if _owner_thread was never set, returns False.
+    """
+
+    owner = getattr(obj, '_owner_thread', None)
+    return owner is not None and owner != threading.get_ident()

--- a/tests/test_unit_tests_threaded.py
+++ b/tests/test_unit_tests_threaded.py
@@ -27,7 +27,7 @@ from unittest.mock import MagicMock, patch
 from c2pa import Builder, C2paError as Error, Reader, C2paSigningAlg as SigningAlg, C2paSignerInfo, Signer, sdk_version  # noqa: E501
 from c2pa import Context, Settings
 from c2pa.c2pa import ManagedResource, Stream, LifecycleState
-from c2pa.lib import is_foreign_process, record_owner_pid
+from c2pa.lib import is_foreign_process, record_owner_pid, is_foreign_thread, record_owner_thread
 
 PROJECT_PATH = os.getcwd()
 FIXTURES_FOLDER = os.path.join(os.path.dirname(__file__), "fixtures")
@@ -60,6 +60,27 @@ def _make_stream(pid_offset):
     obj._stream = MagicMock()  # non-None stream handle
     if pid_offset is not None:
         obj._owner_pid = os.getpid() + pid_offset
+    return obj
+
+
+def _make_resource_with_thread(thread_offset):
+    """Construct a ManagedResource-like object stamped with a synthetic
+    owner thread.
+    thread_offset=0: simulates same-thread teardown
+    thread_offset=1: simulates a foreign-thread teardown
+    thread_offset=None: no _owner_thread stamp
+    """
+    obj = _make_resource(pid_offset=0)
+    if thread_offset is not None:
+        obj._owner_thread = threading.get_ident() + thread_offset
+    return obj
+
+
+def _make_stream_with_thread(thread_offset):
+    """Construct a Stream-like object stamped with a synthetic owner thread."""
+    obj = _make_stream(pid_offset=0)
+    if thread_offset is not None:
+        obj._owner_thread = threading.get_ident() + thread_offset
     return obj
 
 
@@ -178,6 +199,49 @@ class TestManagedResourceForkGuard(unittest.TestCase):
         self.assertFalse(obj._initialized)
 
 
+class TestManagedResourceForeignThreadGuard(unittest.TestCase):
+    """Unit tests for the finalizer-only thread guard.
+
+    Verifies that a collector-driven teardown (__del__) running on a
+    different thread than the one that created the object skips the native
+    free, to avoid freeing recycled addresses that got reused.
+
+    A foreign owner is simulated by setting _owner_thread
+    to a value that isn't the current thread's id.
+    """
+
+    def test_foreign_thread_skips_free_via_del(self):
+        obj = _make_resource_with_thread(thread_offset=1)
+        with patch.object(ManagedResource, '_free_native_ptr') as mock_free:
+            obj.__del__()
+        mock_free.assert_not_called()
+        self.assertEqual(obj._lifecycle_state, LifecycleState.CLOSED)
+        self.assertIsNone(obj._handle)
+
+    def test_own_thread_calls_free_via_del(self):
+        obj = _make_resource_with_thread(thread_offset=0)
+        expected_handle = obj._handle
+        with patch.object(ManagedResource, '_free_native_ptr') as mock_free:
+            obj.__del__()
+        mock_free.assert_called_once_with(expected_handle)
+
+    def test_no_stamp_calls_free_via_del(self):
+        """No _owner_thread (backward-compat) must NOT suppress cleanup."""
+        obj = _make_resource_with_thread(thread_offset=None)
+        with patch.object(ManagedResource, '_free_native_ptr') as mock_free:
+            obj.__del__()
+        mock_free.assert_called_once()
+
+    def test_foreign_thread_close_still_frees(self):
+        """Explicit close() from a foreign thread is deliberate and must
+        still free -- only the finalizer path is thread-guarded."""
+        obj = _make_resource_with_thread(thread_offset=1)
+        expected_handle = obj._handle
+        with patch.object(ManagedResource, '_free_native_ptr') as mock_free:
+            obj._cleanup_resources()
+        mock_free.assert_called_once_with(expected_handle)
+
+
 class TestHelpers(unittest.TestCase):
 
     def test_record_and_detect_own_pid(self):
@@ -193,6 +257,20 @@ class TestHelpers(unittest.TestCase):
     def test_no_stamp_not_foreign(self):
         obj = MagicMock(spec=[])  # no _owner_pid attribute
         self.assertFalse(is_foreign_process(obj))
+
+    def test_record_and_detect_own_thread(self):
+        obj = MagicMock()
+        record_owner_thread(obj)
+        self.assertFalse(is_foreign_thread(obj))
+
+    def test_detect_foreign_thread(self):
+        obj = MagicMock()
+        obj._owner_thread = threading.get_ident() + 1
+        self.assertTrue(is_foreign_thread(obj))
+
+    def test_no_thread_stamp_not_foreign(self):
+        obj = MagicMock(spec=[])  # no _owner_thread attribute
+        self.assertFalse(is_foreign_thread(obj))
 DEFAULT_TEST_FILE = os.path.join(FIXTURES_FOLDER, "C.jpg")
 INGREDIENT_TEST_FILE = os.path.join(FIXTURES_FOLDER, "A.jpg")
 ALTERNATIVE_INGREDIENT_TEST_FILE = os.path.join(FIXTURES_FOLDER, "cloud.jpg")

--- a/tests/test_unit_tests_threaded.py
+++ b/tests/test_unit_tests_threaded.py
@@ -269,8 +269,9 @@ class TestHelpers(unittest.TestCase):
         self.assertTrue(is_foreign_thread(obj))
 
     def test_no_thread_stamp_not_foreign(self):
-        obj = MagicMock(spec=[])  # no _owner_thread attribute
+        obj = MagicMock(spec=[])
         self.assertFalse(is_foreign_thread(obj))
+
 DEFAULT_TEST_FILE = os.path.join(FIXTURES_FOLDER, "C.jpg")
 INGREDIENT_TEST_FILE = os.path.join(FIXTURES_FOLDER, "A.jpg")
 ALTERNATIVE_INGREDIENT_TEST_FILE = os.path.join(FIXTURES_FOLDER, "cloud.jpg")


### PR DESCRIPTION
## Changes in this pull request
Stamp owning threads to avoid finalization issues on recycled addresses 

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
