### PR TITLE
Drop wheel, setuptools and pytest from runtime dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,11 +27,6 @@ dependencies = [
     "requests>=2.0.0"
 ]
 
-[dependency-groups]
-dev = [
-    "pytest>=8.1.0"
-]
-
 [project.scripts]
 download-artifacts = "c2pa.build:download_artifacts"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,10 +22,9 @@ maintainers = [
 ]
 urls = {homepage = "https://contentauthenticity.org", repository = "https://github.com/contentauth/c2pa-python"}
 dependencies = [
-    "wheel>=0.41.2",
-    "setuptools>=68.0.0",
+    # `toml` and `requests` are read at runtime by the `download-artifacts`
+    # console script (src/c2pa/build.py), so they stay.
     "toml>=0.10.2",
-    "pytest>=7.4.0",
     "cryptography>=41.0.0",
     "requests>=2.0.0"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,11 +22,14 @@ maintainers = [
 ]
 urls = {homepage = "https://contentauthenticity.org", repository = "https://github.com/contentauth/c2pa-python"}
 dependencies = [
-    # `toml` and `requests` are read at runtime by the `download-artifacts`
-    # console script (src/c2pa/build.py), so they stay.
     "toml>=0.10.2",
     "cryptography>=41.0.0",
     "requests>=2.0.0"
+]
+
+[dependency-groups]
+dev = [
+    "pytest>=8.1.0"
 ]
 
 [project.scripts]


### PR DESCRIPTION
`wheel`, `setuptools` and `pytest` are declared in `[project.dependencies]`, so
every consumer installs three build/test packages into production environments.
None of the three is imported anywhere under `src/`.

`pytest` is re-declared as a PEP 735 `[dependency-groups] dev` entry rather than
dropped outright, so the manifest still names the test dependency — `uv sync`
and `pip install --group dev` pick it up — while keeping it out of the published
package metadata, which `[project.optional-dependencies]` would not do. The
bound follows `requirements-dev.txt` (`>=8.1.0`) rather than the `>=7.4.0` the
runtime entry carried; nothing installs the older one today.

### Evidence

Every import in the installed package, on `main` (0.37.9):

| Module | Imports |
| --- | --- |
| `src/c2pa/c2pa.py` | stdlib only |
| `src/c2pa/lib.py` | stdlib only |
| `src/c2pa/__init__.py` | stdlib + own module |
| `src/c2pa/build.py` | `requests` (line 16), `toml` (line 97, lazy) |

So `requests` and `toml` are genuine runtime dependencies — `build.py` is the
installed `download-artifacts` console script — and this PR leaves both alone.
`wheel`, `setuptools` and `pytest` are imported by nothing.

This repo already classifies all three correctly in three other places:

* **`[build-system] requires`** already lists `setuptools>=68.0.0` and `wheel`,
  so the build has what it needs; the runtime entries are duplicates.
* **`requirements-dev.txt`** lists `wheel` and `setuptools` under
  `# Build dependencies` and `pytest` under `# Testing dependencies`.
* **`.github/workflows/build.yml`** installs pytest explicitly
  (`pip install pytest`, lines 285 and 377), so CI does not rely on the runtime
  declaration either.

The change is therefore a no-op for this repo's own build and test paths.

### Why it is worth doing

**They reach production images.** In our worker, `uv export --frozen --no-dev` —
the resolver's production set — lists all three. `setuptools` in particular has
a CVE history, so a security scan has to triage findings for packages the
application never imports.

**They mask missing test dependencies downstream, silently.** This is the one
that cost us time. Our own test extra was never actually installed — `uv sync`
does not install extras — and nobody noticed for seven weeks, because `pytest`
arrived through this dependency chain anyway. Our suite ran on a package no
manifest of ours declared, at a version nobody chose, and a fix we shipped in
that window was inert the whole time. A dependency audit is what eventually
flagged it.

### One question, deliberately not in this diff

`cryptography` is also unimported under `src/` — it appears only in `examples/`
and `tests/`, and your own `requirements.txt` says `# only used in the training
example`. It looked like your call rather than mine: dropping it would stop
`pip install c2pa-python` from giving a reader everything the signing examples
need. Happy to extend the PR if you would rather it went too.

